### PR TITLE
Fix inability to detect already bumped

### DIFF
--- a/bump.sh
+++ b/bump.sh
@@ -29,7 +29,7 @@ bump() {
       echo "refusing to tag; $latest_ver already tagged for HEAD ($head_commit)"
   else
       echo "tagging $next_ver $head_commit"
-      git tag -a "$next_ver" -m "Release $next_ver" $head_commit
+      git tag "$next_ver" $head_commit
   fi
 }
 


### PR DESCRIPTION
Something in Git has changed, such that tag messages generated tag refs
different than the commit they were tagging. This caused the script to
bump even if a tag already existed for HEAD.

Removal of the tag message and annotation reverted the behavior to how
git worked when v0.1.0 was released.