### PR TITLE
Add license

### DIFF
--- a/bump.sh
+++ b/bump.sh
@@ -1,4 +1,27 @@
 #!/bin/bash
+#
+# The MIT License
+#
+# Copyright (c) 2016-2017 Tomologic AB
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
 # Bumps the semantic version of the git-project.
 # If no semantic version tags exist in the project, the version starts out at v0.0.0
 # and is incremented by one for the field indicated by the bump command argument.


### PR DESCRIPTION
Going with MIT as per internal discussion for public contribution.
We've used unlicense in other projects, but unlicense preclude usage in some parts of the world (e.g. germany).